### PR TITLE
[Feature] Added a support for PhpDeal annotations handling

### DIFF
--- a/META-INF/plugin.xml
+++ b/META-INF/plugin.xml
@@ -68,6 +68,7 @@
     <completion.contributor language="Go! AOP Pointcut query" implementationClass="com.aopphp.go.PointcutCompletionContributor"/>
     <lang.braceMatcher language="Go! AOP Pointcut query" implementationClass="com.aopphp.go.PointcutQueryPairedBraceMatcher"/>
     <languageInjector implementation="com.aopphp.go.injector.PointcutQueryLanguageInjector"/>
+    <languageInjector implementation="com.aopphp.go.injector.PhpDealAssertInjector"/>
     <annotator language="Go! AOP Pointcut query" implementationClass="com.aopphp.go.annotator.DoctrineAnnotator"/>
     <codeInsight.lineMarkerProvider language="PHP" implementationClass="com.aopphp.go.line.marker.AdvisedElementsLineMarkerProvider" />
 

--- a/README.md
+++ b/README.md
@@ -15,10 +15,15 @@ Install it and [PHP Annotations Plugin](http://plugins.jetbrains.com/plugin/7320
 
 Features
 ----------
-   - Go! AOP pointcut syntax highlighting and parsing
-   - Analysis of pointcuts and line marker to navigate to the concrete advice ![IDEA Pointcut analysis](https://raw.githubusercontent.com/goaop/idea-plugin/master/images/advise-navigation.gif)
-   - Highlighting of incorrect doctrine annotations for @access, @execution and @within pointcuts
-   - Completion of doctrine annotations @access, @execution and @within pointcuts ![Doctrine annotation completion](https://raw.githubusercontent.com/goaop/idea-plugin/master/images/doctrine-completion.gif) 
-   - Completion of visibility modifiers and pointcut keywords
-   - Automatic injection of pointcut language into the Go\Lang\Annotation\* annotations
-   - Color settings adjustment for pointcut expressions
+  - Go! AOP pointcut syntax highlighting and parsing
+  - Analysis of pointcuts and line marker to navigate to the concrete advice ![IDEA Pointcut analysis](https://raw.githubusercontent.com/goaop/idea-plugin/master/images/advise-navigation.gif)
+  - Highlighting of incorrect doctrine annotations for @access, @execution and @within pointcuts
+  - Completion of doctrine annotations @access, @execution and @within pointcuts ![Doctrine annotation completion](https://raw.githubusercontent.com/goaop/idea-plugin/master/images/doctrine-completion.gif)
+  - Completion of visibility modifiers and pointcut keywords
+  - Automatic injection of pointcut language into the Go\Lang\Annotation\* annotations
+  - Color settings adjustment for pointcut expressions
+
+Additional features
+-------------------
+
+  - PHP Language injection into the [Php-Deal Design-by-Contract framework](https://github.com/lisachenko/php-deal)

--- a/idea-go-aop-plugin.iml
+++ b/idea-go-aop-plugin.iml
@@ -7,7 +7,7 @@
       <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/resources" type="java-resource" />
     </content>
-    <orderEntry type="inheritedJdk" />
+    <orderEntry type="jdk" jdkName="PhpStorm PS-139.1348" jdkType="IDEA JDK" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" scope="PROVIDED" name="php-openapi" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="php-annotation" level="project" />

--- a/src/com/aopphp/go/index/AnnotationPointcutExpressionIndex.java
+++ b/src/com/aopphp/go/index/AnnotationPointcutExpressionIndex.java
@@ -3,7 +3,7 @@ package com.aopphp.go.index;
 import com.aopphp.go.pointcut.Pointcut;
 import com.aopphp.go.psi.PointcutElementFactory;
 import com.aopphp.go.psi.PointcutExpression;
-import com.aopphp.go.util.PointcutQueryUtil;
+import com.aopphp.go.util.PluginUtil;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
@@ -135,7 +135,7 @@ public class AnnotationPointcutExpressionIndex extends FileBasedIndexExtension<S
 
         public void visitPhpDocTag(PhpDocTag phpDocTag) {
 
-            String annotationFqnName = PointcutQueryUtil.getClassNameReference(phpDocTag);
+            String annotationFqnName = PluginUtil.getClassNameReference(phpDocTag);
             if(annotationFqnName == null || !annotationFqnName.startsWith("\\Go\\Lang\\Annotation\\")) {
                 return;
             }

--- a/src/com/aopphp/go/injector/PhpDealAssertInjector.java
+++ b/src/com/aopphp/go/injector/PhpDealAssertInjector.java
@@ -1,0 +1,67 @@
+package com.aopphp.go.injector;
+
+import com.aopphp.go.pattern.CodePattern;
+import com.intellij.openapi.util.TextRange;
+import com.intellij.psi.InjectedLanguagePlaces;
+import com.intellij.psi.LanguageInjector;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiLanguageInjectionHost;
+import com.intellij.psi.util.PsiTreeUtil;
+import com.jetbrains.php.lang.PhpLanguage;
+import com.jetbrains.php.lang.documentation.phpdoc.psi.PhpDocComment;
+import com.jetbrains.php.lang.documentation.phpdoc.psi.tags.PhpDocParamTag;
+import com.jetbrains.php.lang.psi.elements.PhpClass;
+import com.jetbrains.php.lang.psi.elements.PhpClassMember;
+import com.jetbrains.php.lang.psi.elements.StringLiteralExpression;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * PhpDeal injector is responsible to inject PHP syntax into the specific annotations
+ */
+public class PhpDealAssertInjector implements LanguageInjector {
+
+    private static final String PHP_DEAL_ANNOTATION = "\\PhpDeal\\Annotation";
+
+    @Override
+    public void getLanguagesToInject(
+            @NotNull PsiLanguageInjectionHost host,
+            @NotNull InjectedLanguagePlaces injectionPlacesRegistrar)
+    {
+        // we accept only PHP literal expressions, such as docBlocks and string for PointcutBuilder->method('<expr>')
+        if (!(host instanceof StringLiteralExpression)) {
+            return;
+        }
+        StringLiteralExpression literalExpression = (StringLiteralExpression) host;
+        if (!CodePattern.isInsideAnnotation(literalExpression, PHP_DEAL_ANNOTATION)) {
+            return;
+        }
+
+        PhpClass classInstance    = null;
+        TextRange rangeInsideHost = new TextRange(1, Math.max(literalExpression.getTextLength()-1, 1));
+        String prefix = "<?php\n";
+        String suffix = ";";
+
+        PhpDocComment phpDocComment = PsiTreeUtil.getParentOfType(literalExpression, PhpDocComment.class);
+        if (phpDocComment != null) {
+            for (PhpDocParamTag param : phpDocComment.getParamTags()) {
+                prefix += "/** @var " + param.getType().toStringResolved() + " $" + param.getVarName() + "*/\n";
+            }
+            PsiElement owner = phpDocComment.getOwner();
+            if (owner instanceof PhpClassMember) {
+                classInstance = ((PhpClassMember) owner).getContainingClass();
+            } else if (owner instanceof PhpClass) {
+                classInstance = (PhpClass) owner;
+            }
+        }
+        if (classInstance != null && !classInstance.isInterface()) {
+            prefix += "/** @var " + classInstance.getFQN() + " $this */\n";
+            prefix += "/** @var " + classInstance.getFQN() + " $__old */\n";
+        }
+
+        prefix += "/** @var mixed $__result */\n";
+        prefix += "/** @noinspection PhpVoidFunctionResultUsedInspection */\n";
+        prefix += "return ";
+
+        injectionPlacesRegistrar.addPlace(PhpLanguage.INSTANCE, rangeInsideHost, prefix, suffix);
+    }
+}

--- a/src/com/aopphp/go/injector/PointcutQueryLanguageInjector.java
+++ b/src/com/aopphp/go/injector/PointcutQueryLanguageInjector.java
@@ -1,23 +1,17 @@
 package com.aopphp.go.injector;
 
 import com.aopphp.go.PointcutQueryLanguage;
+import com.aopphp.go.pattern.CodePattern;
 import com.intellij.openapi.util.TextRange;
 import com.intellij.psi.InjectedLanguagePlaces;
 import com.intellij.psi.LanguageInjector;
-import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiLanguageInjectionHost;
-import com.intellij.psi.util.PsiTreeUtil;
-import com.jetbrains.php.lang.documentation.phpdoc.psi.tags.PhpDocTag;
-import com.jetbrains.php.lang.psi.elements.MethodReference;
-import com.jetbrains.php.lang.psi.elements.ParameterList;
-import com.jetbrains.php.lang.psi.elements.PhpClass;
 import com.jetbrains.php.lang.psi.elements.StringLiteralExpression;
-import com.jetbrains.php.lang.psi.elements.impl.MethodImpl;
-import de.espend.idea.php.annotation.dict.PhpDocTagAnnotation;
-import de.espend.idea.php.annotation.pattern.AnnotationPattern;
-import de.espend.idea.php.annotation.util.AnnotationUtil;
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * PointcutQuery injector is responsible to inject Go! AOP Pointcut syntax into the StringLiteral expressions
+ */
 public class PointcutQueryLanguageInjector implements LanguageInjector {
 
     private static final String GO_AOP_ANNOTATION = "\\Go\\Lang\\Annotation";
@@ -32,70 +26,14 @@ public class PointcutQueryLanguageInjector implements LanguageInjector {
             return;
         }
 
-        boolean enableInjection = isInjectionIntoAnnotation(host);
-        enableInjection |= isInjectionIntoPointcutBuilder(host);
+        StringLiteralExpression literalExpression = (StringLiteralExpression) host;
 
-        if (enableInjection && host.getTextLength() > 1) {
-            TextRange rangeInsideHost = new TextRange(1, host.getTextLength() - 1);
+        boolean enableInjection = CodePattern.isInsideAnnotation(literalExpression, GO_AOP_ANNOTATION);
+        enableInjection |= CodePattern.isInsidePointcutBuilderMethod(literalExpression);
+
+        if (enableInjection) {
+            TextRange rangeInsideHost = new TextRange(1, Math.max(literalExpression.getTextLength()-1, 1));
             injectionPlacesRegistrar.addPlace(PointcutQueryLanguage.INSTANCE, rangeInsideHost, null, null);
         }
-    }
-
-    /**
-     * Checks if injection is performed into PointcutBuilder->method('<pointcutExpression>', function () {...})
-     * @param host Host element is typically PHP string
-     *
-     * @return boolean
-     */
-    private boolean isInjectionIntoPointcutBuilder(PsiLanguageInjectionHost host)
-    {
-        PsiElement element = host.getParent();
-        if (!(element instanceof ParameterList)) {
-            return false;
-        }
-        element = element.getParent();
-        if (!(element instanceof MethodReference)) {
-            return false;
-        }
-
-        MethodImpl methodImpl = (MethodImpl) ((MethodReference) element).resolve();
-        if (methodImpl == null || methodImpl.getFQN() == null) {
-            return false;
-        }
-
-        return methodImpl.getFQN().startsWith("\\Go\\Aop\\Support\\PointcutBuilder");
-    }
-
-    /**
-     * Checks if injection is performed into annotation
-     *
-     * @param host Host element, typically string literal expression
-     *
-     * @return boolean
-     */
-    private boolean isInjectionIntoAnnotation (@NotNull PsiLanguageInjectionHost host)
-    {
-        boolean enableInjection = false;
-
-        PhpDocTag phpDocTag = PsiTreeUtil.getParentOfType(host, PhpDocTag.class);
-        if (phpDocTag == null || !AnnotationPattern.getDocBlockTag().accepts(phpDocTag)) {
-            return false;
-        }
-
-        PhpDocTagAnnotation phpDocAnnotationContainer = AnnotationUtil.getPhpDocAnnotationContainer(phpDocTag);
-        PhpClass phpClass = null;
-        if (phpDocAnnotationContainer != null) {
-            phpClass = phpDocAnnotationContainer.getPhpClass();
-        }
-
-        if (phpClass == null || phpClass.getFQN() == null) {
-            return false;
-        }
-
-        if (phpClass.getFQN().startsWith(GO_AOP_ANNOTATION)) {
-            enableInjection = true;
-        }
-
-        return enableInjection;
     }
 }

--- a/src/com/aopphp/go/pattern/CodePattern.java
+++ b/src/com/aopphp/go/pattern/CodePattern.java
@@ -1,10 +1,24 @@
 package com.aopphp.go.pattern;
 
 import com.aopphp.go.PointcutQueryLanguage;
-import com.aopphp.go.psi.*;
+import com.aopphp.go.psi.AnnotatedAccessPointcut;
+import com.aopphp.go.psi.AnnotatedExecutionPointcut;
+import com.aopphp.go.psi.AnnotatedWithinPointcut;
+import com.aopphp.go.psi.PointcutTypes;
 import com.intellij.patterns.ElementPattern;
 import com.intellij.patterns.PlatformPatterns;
 import com.intellij.psi.PsiElement;
+import com.intellij.psi.util.PsiTreeUtil;
+import com.jetbrains.php.lang.documentation.phpdoc.psi.tags.PhpDocTag;
+import com.jetbrains.php.lang.psi.elements.MethodReference;
+import com.jetbrains.php.lang.psi.elements.ParameterList;
+import com.jetbrains.php.lang.psi.elements.PhpClass;
+import com.jetbrains.php.lang.psi.elements.StringLiteralExpression;
+import com.jetbrains.php.lang.psi.elements.impl.MethodImpl;
+import de.espend.idea.php.annotation.dict.PhpDocTagAnnotation;
+import de.espend.idea.php.annotation.pattern.AnnotationPattern;
+import de.espend.idea.php.annotation.util.AnnotationUtil;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Code pattern contains some useful patterns for matching items
@@ -45,5 +59,58 @@ public class CodePattern extends PlatformPatterns {
                 psiElement(PointcutTypes.ACCESS)
             )
         );
+    }
+
+    /**
+     * Checks if host is concrete annotation to inject syntax into it
+     *
+     * @param host Host element, typically string literal expression
+     * @param annotationPrefix Annotation prefix
+     * @return boolean
+     */
+    public static boolean isInsideAnnotation(@NotNull StringLiteralExpression host, String annotationPrefix) {
+
+        PhpDocTag phpDocTag = PsiTreeUtil.getParentOfType(host, PhpDocTag.class);
+        if (phpDocTag == null || !AnnotationPattern.getDocBlockTag().accepts(phpDocTag)) {
+            return false;
+        }
+
+        PhpDocTagAnnotation phpDocAnnotationContainer = AnnotationUtil.getPhpDocAnnotationContainer(phpDocTag);
+        PhpClass phpClass = null;
+        if (phpDocAnnotationContainer != null) {
+            phpClass = phpDocAnnotationContainer.getPhpClass();
+        }
+
+        if (phpClass == null || phpClass.getFQN() == null) {
+            return false;
+        }
+
+        return phpClass.getFQN().startsWith(annotationPrefix);
+
+    }
+
+    /**
+     * Checks if host is PointcutBuilder->method('<pointcutExpression>', function () {...})
+     * @param host Host element is typically PHP string
+     *
+     * @return boolean
+     */
+    public static boolean isInsidePointcutBuilderMethod(StringLiteralExpression host)
+    {
+        PsiElement element = host.getParent();
+        if (!(element instanceof ParameterList)) {
+            return false;
+        }
+        element = element.getParent();
+        if (!(element instanceof MethodReference)) {
+            return false;
+        }
+
+        MethodImpl methodImpl = (MethodImpl) ((MethodReference) element).resolve();
+        if (methodImpl == null || methodImpl.getFQN() == null) {
+            return false;
+        }
+
+        return methodImpl.getFQN().startsWith("\\Go\\Aop\\Support\\PointcutBuilder");
     }
 }

--- a/src/com/aopphp/go/pointcut/PointcutAdvisor.java
+++ b/src/com/aopphp/go/pointcut/PointcutAdvisor.java
@@ -1,7 +1,7 @@
 package com.aopphp.go.pointcut;
 
 import com.aopphp.go.index.AnnotationPointcutExpressionIndex;
-import com.aopphp.go.util.PointcutQueryUtil;
+import com.aopphp.go.util.PluginUtil;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.search.GlobalSearchScope;
 import com.intellij.util.indexing.FileBasedIndex;
@@ -104,7 +104,7 @@ public class PointcutAdvisor {
 
         if (element instanceof PhpClass) {
             PhpClass instance = (PhpClass) element;
-            if (instance.isInterface() || PointcutQueryUtil.isAspect(instance)) {
+            if (instance.isInterface() || PluginUtil.isAspect(instance)) {
                 return false;
             }
             return filterKind.contains(KindFilter.KIND_CLASS);

--- a/src/com/aopphp/go/util/PluginUtil.java
+++ b/src/com/aopphp/go/util/PluginUtil.java
@@ -5,7 +5,6 @@ import com.intellij.psi.PsiFile;
 import com.intellij.psi.PsiRecursiveElementWalkingVisitor;
 import com.jetbrains.php.lang.documentation.phpdoc.psi.tags.PhpDocTag;
 import com.jetbrains.php.lang.psi.elements.PhpClass;
-import com.jetbrains.php.lang.psi.elements.PhpNamedElement;
 import com.jetbrains.php.lang.psi.elements.PhpUse;
 import org.apache.commons.lang.StringUtils;
 import org.jetbrains.annotations.Nullable;
@@ -13,7 +12,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.HashMap;
 import java.util.Map;
 
-public class PointcutQueryUtil {
+public class PluginUtil {
 
     /**
      * Returns a map with php use imports


### PR DESCRIPTION
This PR introduces a PHP language injection for Php-Deal design-by-contract framework. So, all autocompletion and other things should work.

<img width="487" alt="dbc-highlight" src="https://cloud.githubusercontent.com/assets/640114/14225381/1cd47d52-f8d2-11e5-8e5b-050f6ae852d1.png">
