### PR TITLE
PhpUse#getOriginal is deprecated, use #getFQN instead

### DIFF
--- a/src/com/aopphp/go/util/PluginUtil.java
+++ b/src/com/aopphp/go/util/PluginUtil.java
@@ -36,9 +36,9 @@ public class PluginUtil {
             private void visitUse(PhpUse phpUse) {
                 String alias = phpUse.getAliasName();
                 if(alias != null) {
-                    useImports.put(alias, phpUse.getOriginal());
+                    useImports.put(alias, phpUse.getFQN());
                 } else {
-                    useImports.put(phpUse.getName(), phpUse.getOriginal());
+                    useImports.put(phpUse.getName(), phpUse.getFQN());
                 }
             }
 


### PR DESCRIPTION
PhpUse#getOriginal is deprecated since PhpStorm 2016.1. This method was always returning almost the same value as #getFQN so this change most probably will not break anything. Unfortunately I've no chance to check it so it would be great if you'll perform some tests before or just after the merge. This pull request is rather notification than complete fix.
