### PR TITLE
improve indexing performance, implement equals/hashCode for values

### DIFF
--- a/src/com/aopphp/go/index/AbstractDataIndexer.java
+++ b/src/com/aopphp/go/index/AbstractDataIndexer.java
@@ -1,0 +1,47 @@
+package com.aopphp.go.index;
+
+import com.intellij.psi.util.PsiTreeUtil;
+import com.jetbrains.php.lang.documentation.phpdoc.psi.PhpDocComment;
+import com.jetbrains.php.lang.documentation.phpdoc.psi.tags.PhpDocTag;
+import com.jetbrains.php.lang.psi.PhpFile;
+import com.jetbrains.php.lang.psi.elements.Function;
+import com.jetbrains.php.lang.psi.elements.PhpClass;
+import com.jetbrains.php.lang.psi.elements.PhpClassMember;
+import com.jetbrains.php.lang.psi.elements.PhpNamedElement;
+import gnu.trove.THashMap;
+
+import java.util.Map;
+
+abstract class AbstractDataIndexer<T> {
+
+    private final Map<String, T> map = new THashMap<>();
+    private final PhpFile phpFile;
+
+    AbstractDataIndexer(final PhpFile phpFile) {
+        this.phpFile = phpFile;
+    }
+
+    Map<String, T> map() {
+        for (final PhpNamedElement element : phpFile.getTopLevelDefs().values()) {
+            if (element instanceof Function) {
+                visitPhpNamedElement(element, map);
+            } else if (element instanceof PhpClass) {
+                for (PhpClassMember member : PsiTreeUtil.getChildrenOfTypeAsList(element, PhpClassMember.class)) {
+                    visitPhpNamedElement(member, map);
+                }
+            }
+        }
+        return map;
+    }
+
+    private void visitPhpNamedElement(final PhpNamedElement element, final Map<String, T> map) {
+        final PhpDocComment docComment = element.getDocComment();
+        if (docComment != null) {
+            for (final PhpDocTag phpDocTag : PsiTreeUtil.getChildrenOfTypeAsList(docComment, PhpDocTag.class)) {
+                visitPhpDocTag(phpDocTag, map);
+            }
+        }
+    }
+
+    protected abstract void visitPhpDocTag(final PhpDocTag phpDocTag, final Map<String, T> map);
+}

--- a/src/com/aopphp/go/index/AnnotatedPhpNamedElementIndex.java
+++ b/src/com/aopphp/go/index/AnnotatedPhpNamedElementIndex.java
@@ -4,6 +4,7 @@ import com.aopphp.go.util.PluginUtil;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.util.PsiTreeUtil;
+import com.intellij.util.ReflectionUtil;
 import com.intellij.util.indexing.*;
 import com.intellij.util.io.DataExternalizer;
 import com.intellij.util.io.EnumeratorStringDescriptor;
@@ -28,7 +29,7 @@ public class AnnotatedPhpNamedElementIndex extends FileBasedIndexExtension<Strin
 
     public static final ID<String, Set<String>> KEY = ID.create("com.aopphp.go.annotated.elements");
     private static final KeyDescriptor<String> ENUMERATOR_STRING_DESCRIPTOR = new EnumeratorStringDescriptor();
-    private static final StringSetDataExternalizer STRING_SET_DATA_EXTERNALIZER = new StringSetDataExternalizer();
+    private static final StringSetDataExternalizer STRING_SET_DATA_EXTERNALIZER = ReflectionUtil.newInstance(StringSetDataExternalizer.class);
 
     @NotNull
     @Override

--- a/src/com/aopphp/go/index/AnnotatedPhpNamedElementIndex.java
+++ b/src/com/aopphp/go/index/AnnotatedPhpNamedElementIndex.java
@@ -3,7 +3,6 @@ package com.aopphp.go.index;
 import com.aopphp.go.util.PluginUtil;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
-import com.intellij.psi.PsiRecursiveElementWalkingVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
 import com.intellij.util.indexing.*;
 import com.intellij.util.io.DataExternalizer;
@@ -14,47 +13,53 @@ import com.jetbrains.php.lang.documentation.phpdoc.psi.tags.PhpDocTag;
 import com.jetbrains.php.lang.psi.PhpFile;
 import com.jetbrains.php.lang.psi.elements.PhpNamedElement;
 import com.jetbrains.php.lang.psi.stubs.indexes.PhpConstantNameIndex;
-import gnu.trove.THashMap;
+import com.jetbrains.php.lang.psi.stubs.indexes.StringSetDataExternalizer;
+import gnu.trove.THashSet;
 import org.jetbrains.annotations.NotNull;
 
-import java.io.DataInput;
-import java.io.DataOutput;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.Collections;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * This index collects all annotated elements in the files
  */
-public class AnnotatedPhpNamedElementIndex extends FileBasedIndexExtension<String, List<String>> {
+public class AnnotatedPhpNamedElementIndex extends FileBasedIndexExtension<String, Set<String>> {
 
-    public static final ID<String, List<String>> KEY = ID.create("com.aopphp.go.annotated.elements");
-    private final KeyDescriptor<String> keyDescriptor = new EnumeratorStringDescriptor();
+    public static final ID<String, Set<String>> KEY = ID.create("com.aopphp.go.annotated.elements");
+    private static final KeyDescriptor<String> ENUMERATOR_STRING_DESCRIPTOR = new EnumeratorStringDescriptor();
+    private static final StringSetDataExternalizer STRING_SET_DATA_EXTERNALIZER = new StringSetDataExternalizer();
 
     @NotNull
     @Override
-    public ID<String, List<String>> getName() {
+    public ID<String, Set<String>> getName() {
         return KEY;
     }
 
     @NotNull
     @Override
-    public DataIndexer<String, List<String>, FileContent> getIndexer() {
-        return new DataIndexer<String, List<String>, FileContent>() {
+    public DataIndexer<String, Set<String>, FileContent> getIndexer() {
+        return new DataIndexer<String, Set<String>, FileContent>() {
             @NotNull
             @Override
-            public Map<String, List<String>> map(@NotNull FileContent inputData) {
-                final Map<String, List<String>> map = new THashMap<>();
-
+            public Map<String, Set<String>> map(@NotNull FileContent inputData) {
                 PsiFile psiFile = inputData.getPsiFile();
                 if(!(psiFile instanceof PhpFile)) {
-                    return map;
+                    return Collections.emptyMap();
                 }
 
-                psiFile.accept(new DocTagRecursiveElementVisitor(map));
+                return new AbstractDataIndexer<Set<String>>((PhpFile) psiFile) {
 
-                return map;
+                    private Map<String, String> fileImports;
+
+                    @Override
+                    protected void visitPhpDocTag(final PhpDocTag phpDocTag, final Map<String, Set<String>> map) {
+                        if (fileImports == null) {
+                            fileImports = PluginUtil.getFileUseImports(phpDocTag.getContainingFile());
+                        }
+                        AnnotatedPhpNamedElementIndex.visitPhpDocTag(phpDocTag, fileImports, map);
+                    }
+                }.map();
             }
         };
     }
@@ -62,13 +67,13 @@ public class AnnotatedPhpNamedElementIndex extends FileBasedIndexExtension<Strin
     @NotNull
     @Override
     public KeyDescriptor<String> getKeyDescriptor() {
-        return this.keyDescriptor;
+        return ENUMERATOR_STRING_DESCRIPTOR;
     }
 
     @NotNull
     @Override
-    public DataExternalizer<List<String>> getValueExternalizer() {
-        return new StringCollectionExternalizer();
+    public DataExternalizer<Set<String>> getValueExternalizer() {
+        return STRING_SET_DATA_EXTERNALIZER;
     }
 
     @NotNull
@@ -84,88 +89,38 @@ public class AnnotatedPhpNamedElementIndex extends FileBasedIndexExtension<Strin
 
     @Override
     public int getVersion() {
-        return 1;
+        return 2;
     }
 
-    private static class DocTagRecursiveElementVisitor extends PsiRecursiveElementWalkingVisitor {
-
-        private final Map<String, List<String>> map;
-        private Map<String, String> fileImports;
-
-        public DocTagRecursiveElementVisitor(Map<String, List<String>> map) {
-            this.map = map;
+    private static void visitPhpDocTag(final PhpDocTag phpDocTag, final Map<String, String> fileImports,
+                                       final Map<String, Set<String>> map) {
+        String annotationFqnName = PluginUtil.getClassNameReference(phpDocTag, fileImports);
+        if(annotationFqnName == null) {
+            return;
         }
 
-        @Override
-        public void visitElement(PsiElement element) {
-            if ((element instanceof PhpDocTag)) {
-                visitPhpDocTag((PhpDocTag) element);
-            }
-            super.visitElement(element);
+        // | - PhpDocComment
+        // |   | - PhpDocTag
+        // |
+        // | - PhpNamedElement
+
+        PhpDocComment docComment = PsiTreeUtil.getParentOfType(phpDocTag, PhpDocComment.class);
+        if (docComment == null) {
+            return;
         }
 
-        public void visitPhpDocTag(PhpDocTag phpDocTag) {
-
-
-            // init file imports
-            if(this.fileImports == null) {
-                this.fileImports = PluginUtil.getFileUseImports(phpDocTag.getContainingFile());
-            }
-
-            String annotationFqnName = PluginUtil.getClassNameReference(phpDocTag, this.fileImports);
-            if(annotationFqnName == null) {
-                return;
-            }
-
-            // | - PhpDocComment
-            // |   | - PhpDocTag
-            // |
-            // | - PhpNamedElement
-
-            PhpDocComment docComment = PsiTreeUtil.getParentOfType(phpDocTag, PhpDocComment.class);
-            if (docComment == null) {
-                return;
-            }
-
-            PsiElement phpNamedElement = docComment.getOwner();
-            if (phpNamedElement == null || !(phpNamedElement instanceof PhpNamedElement)) {
-                return;
-            }
-            String elementFQN = ((PhpNamedElement) phpNamedElement).getFQN();
-            if (map.containsKey(annotationFqnName)) {
-                List<String> strings = map.get(annotationFqnName);
-                strings.add(elementFQN);
-            } else {
-                ArrayList<String> strings = new ArrayList<>();
-                strings.add(elementFQN);
-                map.put(annotationFqnName, strings);
-            }
+        PsiElement phpNamedElement = docComment.getOwner();
+        if (phpNamedElement == null || !(phpNamedElement instanceof PhpNamedElement)) {
+            return;
         }
-    }
-
-    /**
-     * Internal class to store and load the list of strings
-     */
-    private static class StringCollectionExternalizer implements DataExternalizer<List<String>> {
-
-        @Override
-        public void save(@NotNull DataOutput dataOutput, List<String> strings) throws IOException {
-            dataOutput.writeInt(strings.size());
-            for (String element : strings) {
-                dataOutput.writeUTF(element);
-            }
-        }
-
-        @Override
-        public List<String> read(@NotNull DataInput dataInput) throws IOException {
-            int length = dataInput.readInt();
-            List<String> strings = new ArrayList<>();
-            for (int i=0; i<length; i++) {
-                strings.add(dataInput.readUTF());
-            }
-
-            return strings;
+        String elementFQN = ((PhpNamedElement) phpNamedElement).getFQN();
+        if (map.containsKey(annotationFqnName)) {
+            Set<String> strings = map.get(annotationFqnName);
+            strings.add(elementFQN);
+        } else {
+            Set<String> strings = new THashSet<>();
+            strings.add(elementFQN);
+            map.put(annotationFqnName, strings);
         }
     }
 }
-

--- a/src/com/aopphp/go/pointcut/AndPointFilter.java
+++ b/src/com/aopphp/go/pointcut/AndPointFilter.java
@@ -46,4 +46,24 @@ public class AndPointFilter implements PointFilter {
     public boolean matches(PhpNamedElement element) {
         return first.matches(element) && second.matches(element);
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof AndPointFilter)) return false;
+
+        AndPointFilter that = (AndPointFilter) o;
+
+        if (!kind.equals(that.kind)) return false;
+        if (!first.equals(that.first)) return false;
+        return second.equals(that.second);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = kind.hashCode();
+        result = 31 * result + first.hashCode();
+        result = 31 * result + second.hashCode();
+        return result;
+    }
 }

--- a/src/com/aopphp/go/pointcut/AndPointcut.java
+++ b/src/com/aopphp/go/pointcut/AndPointcut.java
@@ -79,4 +79,26 @@ public class AndPointcut implements Pointcut {
 
         return pointcut.matches(point) && pointcut.getClassFilter().matches(containingClass);
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof AndPointcut)) return false;
+
+        AndPointcut that = (AndPointcut) o;
+
+        if (!kind.equals(that.kind)) return false;
+        if (!classFilter.equals(that.classFilter)) return false;
+        if (!first.equals(that.first)) return false;
+        return second.equals(that.second);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = kind.hashCode();
+        result = 31 * result + classFilter.hashCode();
+        result = 31 * result + first.hashCode();
+        result = 31 * result + second.hashCode();
+        return result;
+    }
 }

--- a/src/com/aopphp/go/pointcut/AnnotationPointcut.java
+++ b/src/com/aopphp/go/pointcut/AnnotationPointcut.java
@@ -103,7 +103,7 @@ public class AnnotationPointcut implements Pointcut
 
         private static final Set<KindFilter> KIND_CLASS = Collections.singleton(KindFilter.KIND_CLASS);
         private static final FileBasedIndex INDEX = FileBasedIndex.getInstance();
-        private static final ID<String, List<String>> KEY = AnnotatedPhpNamedElementIndex.KEY;
+        private static final ID<String, Set<String>> KEY = AnnotatedPhpNamedElementIndex.KEY;
 
 
         private String annotationName;
@@ -124,9 +124,9 @@ public class AnnotationPointcut implements Pointcut
             }
 
             GlobalSearchScope searchScope = PhpIndex.getInstance(element.getProject()).getSearchScope();
-            List<List<String>> values     = INDEX.getValues(KEY, annotationName, searchScope);
+            List<Set<String>> values     = INDEX.getValues(KEY, annotationName, searchScope);
             if (values.size() > 0) {
-                List<String> phpElementsFQN = values.get(0);
+                Set<String> phpElementsFQN = values.get(0);
                 for (String phpElementFQN : phpElementsFQN) {
                     if (phpElementFQN.startsWith(elementFQN)) {
                         return true;
@@ -141,5 +141,40 @@ public class AnnotationPointcut implements Pointcut
         public Set<KindFilter> getKind() {
             return KIND_CLASS;
         }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof AnnotatedPhpNamedElementClassFilter)) return false;
+
+            AnnotatedPhpNamedElementClassFilter that = (AnnotatedPhpNamedElementClassFilter) o;
+
+            return annotationName.equals(that.annotationName);
+        }
+
+        @Override
+        public int hashCode() {
+            return annotationName.hashCode();
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof AnnotationPointcut)) return false;
+
+        AnnotationPointcut that = (AnnotationPointcut) o;
+
+        if (!classFilter.equals(that.classFilter)) return false;
+        if (!filterKind.equals(that.filterKind)) return false;
+        return expectedClass.equals(that.expectedClass);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = classFilter.hashCode();
+        result = 31 * result + filterKind.hashCode();
+        result = 31 * result + expectedClass.hashCode();
+        return result;
     }
 }

--- a/src/com/aopphp/go/pointcut/InheritanceClassFilter.java
+++ b/src/com/aopphp/go/pointcut/InheritanceClassFilter.java
@@ -49,4 +49,19 @@ public class InheritanceClassFilter implements PointFilter {
 
         return PhpClassHierarchyUtils.getAllSubclasses(parentClass).contains(element);
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof InheritanceClassFilter)) return false;
+
+        InheritanceClassFilter that = (InheritanceClassFilter) o;
+
+        return parentClassName.equals(that.parentClassName);
+    }
+
+    @Override
+    public int hashCode() {
+        return parentClassName.hashCode();
+    }
 }

--- a/src/com/aopphp/go/pointcut/MemberAccessMatcherFilter.java
+++ b/src/com/aopphp/go/pointcut/MemberAccessMatcherFilter.java
@@ -35,4 +35,19 @@ public class MemberAccessMatcherFilter implements PointFilter {
 
         return allowedAccess.contains(modifier.getAccess());
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof MemberAccessMatcherFilter)) return false;
+
+        MemberAccessMatcherFilter that = (MemberAccessMatcherFilter) o;
+
+        return allowedAccess.equals(that.allowedAccess);
+    }
+
+    @Override
+    public int hashCode() {
+        return allowedAccess.hashCode();
+    }
 }

--- a/src/com/aopphp/go/pointcut/MemberStateMatcherFilter.java
+++ b/src/com/aopphp/go/pointcut/MemberStateMatcherFilter.java
@@ -35,4 +35,19 @@ public class MemberStateMatcherFilter implements PointFilter {
 
         return allowedState.equals(modifier.getState());
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof MemberStateMatcherFilter)) return false;
+
+        MemberStateMatcherFilter that = (MemberStateMatcherFilter) o;
+
+        return allowedState == that.allowedState;
+    }
+
+    @Override
+    public int hashCode() {
+        return allowedState.hashCode();
+    }
 }

--- a/src/com/aopphp/go/pointcut/NotPointFilter.java
+++ b/src/com/aopphp/go/pointcut/NotPointFilter.java
@@ -34,4 +34,22 @@ public class NotPointFilter implements PointFilter {
     public boolean matches(PhpNamedElement element) {
         return !first.matches(element);
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof NotPointFilter)) return false;
+
+        NotPointFilter that = (NotPointFilter) o;
+
+        if (!kind.equals(that.kind)) return false;
+        return first.equals(that.first);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = kind.hashCode();
+        result = 31 * result + first.hashCode();
+        return result;
+    }
 }

--- a/src/com/aopphp/go/pointcut/NotPointcut.java
+++ b/src/com/aopphp/go/pointcut/NotPointcut.java
@@ -56,4 +56,24 @@ public class NotPointcut implements Pointcut {
 
         return !pointcut.matches(element);
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof NotPointcut)) return false;
+
+        NotPointcut that = (NotPointcut) o;
+
+        if (!kind.equals(that.kind)) return false;
+        if (!classFilter.equals(that.classFilter)) return false;
+        return pointcut.equals(that.pointcut);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = kind.hashCode();
+        result = 31 * result + classFilter.hashCode();
+        result = 31 * result + pointcut.hashCode();
+        return result;
+    }
 }

--- a/src/com/aopphp/go/pointcut/OrPointFilter.java
+++ b/src/com/aopphp/go/pointcut/OrPointFilter.java
@@ -46,4 +46,24 @@ public class OrPointFilter implements PointFilter {
     public boolean matches(PhpNamedElement element) {
         return first.matches(element) || second.matches(element);
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof OrPointFilter)) return false;
+
+        OrPointFilter that = (OrPointFilter) o;
+
+        if (!kind.equals(that.kind)) return false;
+        if (!first.equals(that.first)) return false;
+        return second.equals(that.second);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = kind.hashCode();
+        result = 31 * result + first.hashCode();
+        result = 31 * result + second.hashCode();
+        return result;
+    }
 }

--- a/src/com/aopphp/go/pointcut/SignaturePointcut.java
+++ b/src/com/aopphp/go/pointcut/SignaturePointcut.java
@@ -62,4 +62,28 @@ public class SignaturePointcut implements Pointcut
     public Set<KindFilter> getKind() {
         return filterKind;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof SignaturePointcut)) return false;
+
+        SignaturePointcut that = (SignaturePointcut) o;
+
+        if (!filterKind.equals(that.filterKind)) return false;
+        if (!name.equals(that.name)) return false;
+        if (!regexp.equals(that.regexp)) return false;
+        if (!modifierFilter.equals(that.modifierFilter)) return false;
+        return classFilter != null ? classFilter.equals(that.classFilter) : that.classFilter == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = filterKind.hashCode();
+        result = 31 * result + name.hashCode();
+        result = 31 * result + regexp.hashCode();
+        result = 31 * result + modifierFilter.hashCode();
+        result = 31 * result + (classFilter != null ? classFilter.hashCode() : 0);
+        return result;
+    }
 }

--- a/src/com/aopphp/go/pointcut/SignaturePointcut.java
+++ b/src/com/aopphp/go/pointcut/SignaturePointcut.java
@@ -72,7 +72,6 @@ public class SignaturePointcut implements Pointcut
 
         if (!filterKind.equals(that.filterKind)) return false;
         if (!name.equals(that.name)) return false;
-        if (!regexp.equals(that.regexp)) return false;
         if (!modifierFilter.equals(that.modifierFilter)) return false;
         return classFilter != null ? classFilter.equals(that.classFilter) : that.classFilter == null;
     }
@@ -81,7 +80,6 @@ public class SignaturePointcut implements Pointcut
     public int hashCode() {
         int result = filterKind.hashCode();
         result = 31 * result + name.hashCode();
-        result = 31 * result + regexp.hashCode();
         result = 31 * result + modifierFilter.hashCode();
         result = 31 * result + (classFilter != null ? classFilter.hashCode() : 0);
         return result;

--- a/src/com/aopphp/go/pointcut/TruePointFilter.java
+++ b/src/com/aopphp/go/pointcut/TruePointFilter.java
@@ -14,7 +14,7 @@ public class TruePointFilter implements PointFilter
     private static final Set<KindFilter> KIND_ALL = new HashSet<KindFilter>(Arrays.asList(KindFilter.values())) ;
 
     private static final TruePointFilter INSTANCE = new TruePointFilter();
-    TruePointFilter() {};
+    private TruePointFilter() {};
 
     public static PointFilter getInstance()
     {
@@ -29,5 +29,10 @@ public class TruePointFilter implements PointFilter
     @Override
     public Set<KindFilter> getKind() {
         return KIND_ALL;
+    }
+
+    @Override
+    public int hashCode() {
+        return 0;
     }
 }

--- a/src/com/aopphp/go/pointcut/TruePointFilter.java
+++ b/src/com/aopphp/go/pointcut/TruePointFilter.java
@@ -9,7 +9,7 @@ import java.util.Set;
 /**
  * Canonical PointFilter instance that matches all points.
  */
-public class TruePointFilter implements PointFilter
+public final class TruePointFilter implements PointFilter
 {
     private static final Set<KindFilter> KIND_ALL = new HashSet<KindFilter>(Arrays.asList(KindFilter.values())) ;
 
@@ -34,5 +34,10 @@ public class TruePointFilter implements PointFilter
     @Override
     public int hashCode() {
         return 0;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return obj instanceof TruePointFilter;
     }
 }

--- a/src/com/aopphp/go/pointcut/TruePointcut.java
+++ b/src/com/aopphp/go/pointcut/TruePointcut.java
@@ -45,4 +45,22 @@ public class TruePointcut implements Pointcut
     public Set<KindFilter> getKind() {
         return kind;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof TruePointcut)) return false;
+
+        TruePointcut that = (TruePointcut) o;
+
+        if (!classFilter.equals(that.classFilter)) return false;
+        return kind.equals(that.kind);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = classFilter.hashCode();
+        result = 31 * result + kind.hashCode();
+        return result;
+    }
 }

--- a/src/com/aopphp/go/psi/impl/PointcutQueryPsiUtil.java
+++ b/src/com/aopphp/go/psi/impl/PointcutQueryPsiUtil.java
@@ -16,7 +16,10 @@ import java.util.Set;
  */
 public class PointcutQueryPsiUtil {
 
-    private static final Pointcut NEVER_MATCHES_POINTCUT = new Pointcut() {
+    private static final Pointcut NEVER_MATCHES_POINTCUT = new NeverMatchesPointcut();
+
+    private static final class NeverMatchesPointcut implements Pointcut {
+
         @Override
         public PointFilter getClassFilter() {
             return TruePointFilter.getInstance();
@@ -36,7 +39,12 @@ public class PointcutQueryPsiUtil {
         public int hashCode() {
             return 0;
         }
-    };
+
+        @Override
+        public boolean equals(Object obj) {
+            return obj instanceof NeverMatchesPointcut;
+        }
+    }
 
     /**
      * Returns an absolute FQN for namespace name node

--- a/src/com/aopphp/go/psi/impl/PointcutQueryPsiUtil.java
+++ b/src/com/aopphp/go/psi/impl/PointcutQueryPsiUtil.java
@@ -16,6 +16,28 @@ import java.util.Set;
  */
 public class PointcutQueryPsiUtil {
 
+    private static final Pointcut NEVER_MATCHES_POINTCUT = new Pointcut() {
+        @Override
+        public PointFilter getClassFilter() {
+            return TruePointFilter.getInstance();
+        }
+
+        @Override
+        public boolean matches(PhpNamedElement element) {
+            return false;
+        }
+
+        @Override
+        public Set<KindFilter> getKind() {
+            return Collections.emptySet();
+        }
+
+        @Override
+        public int hashCode() {
+            return 0;
+        }
+    };
+
     /**
      * Returns an absolute FQN for namespace name node
      *
@@ -146,22 +168,7 @@ public class PointcutQueryPsiUtil {
         }
 
         // Pointcut that never matches
-        return new Pointcut() {
-            @Override
-            public PointFilter getClassFilter() {
-                return TruePointFilter.getInstance();
-            }
-
-            @Override
-            public boolean matches(PhpNamedElement element) {
-                return false;
-            }
-
-            @Override
-            public Set<KindFilter> getKind() {
-                return Collections.emptySet();
-            }
-        };
+        return NEVER_MATCHES_POINTCUT;
     }
 
     @NotNull

--- a/src/com/aopphp/go/util/PluginUtil.java
+++ b/src/com/aopphp/go/util/PluginUtil.java
@@ -2,18 +2,15 @@ package com.aopphp.go.util;
 
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
-import com.jetbrains.php.codeInsight.PhpCodeInsightUtil;
 import com.jetbrains.php.lang.documentation.phpdoc.psi.tags.PhpDocTag;
 import com.jetbrains.php.lang.psi.PhpFile;
 import com.jetbrains.php.lang.psi.elements.PhpClass;
-import com.jetbrains.php.lang.psi.elements.PhpPsiElement;
+import com.jetbrains.php.lang.psi.elements.PhpNamedElement;
 import com.jetbrains.php.lang.psi.elements.PhpUse;
-import com.jetbrains.php.lang.psi.elements.PhpUseList;
 import org.apache.commons.lang.StringUtils;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 public class PluginUtil {
@@ -30,9 +27,9 @@ public class PluginUtil {
         final Map<String, String> useImports = new HashMap<String, String>();
 
         if (psiFile instanceof PhpFile) {
-            final List<PhpUseList> useLists = PhpCodeInsightUtil.collectImports((PhpPsiElement) psiFile);
-            for (final PhpUseList useList : useLists) {
-                for (final PhpUse phpUse : useList.getDeclarations()) {
+            for (final PhpNamedElement element : ((PhpFile) psiFile).getTopLevelDefs().values()) {
+                if (element instanceof PhpUse) {
+                    final PhpUse phpUse = (PhpUse) element;
                     String alias = phpUse.getAliasName();
                     if(alias != null) {
                         useImports.put(alias, phpUse.getFQN());

--- a/src/com/aopphp/go/util/PluginUtil.java
+++ b/src/com/aopphp/go/util/PluginUtil.java
@@ -2,14 +2,18 @@ package com.aopphp.go.util;
 
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
-import com.intellij.psi.PsiRecursiveElementWalkingVisitor;
+import com.jetbrains.php.codeInsight.PhpCodeInsightUtil;
 import com.jetbrains.php.lang.documentation.phpdoc.psi.tags.PhpDocTag;
+import com.jetbrains.php.lang.psi.PhpFile;
 import com.jetbrains.php.lang.psi.elements.PhpClass;
+import com.jetbrains.php.lang.psi.elements.PhpPsiElement;
 import com.jetbrains.php.lang.psi.elements.PhpUse;
+import com.jetbrains.php.lang.psi.elements.PhpUseList;
 import org.apache.commons.lang.StringUtils;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class PluginUtil {
@@ -24,25 +28,20 @@ public class PluginUtil {
 
         // search for use alias in local file
         final Map<String, String> useImports = new HashMap<String, String>();
-        psiFile.acceptChildren(new PsiRecursiveElementWalkingVisitor() {
-            @Override
-            public void visitElement(PsiElement element) {
-                if(element instanceof PhpUse) {
-                    visitUse((PhpUse) element);
-                }
-                super.visitElement(element);
-            }
 
-            private void visitUse(PhpUse phpUse) {
-                String alias = phpUse.getAliasName();
-                if(alias != null) {
-                    useImports.put(alias, phpUse.getFQN());
-                } else {
-                    useImports.put(phpUse.getName(), phpUse.getFQN());
+        if (psiFile instanceof PhpFile) {
+            final List<PhpUseList> useLists = PhpCodeInsightUtil.collectImports((PhpPsiElement) psiFile);
+            for (final PhpUseList useList : useLists) {
+                for (final PhpUse phpUse : useList.getDeclarations()) {
+                    String alias = phpUse.getAliasName();
+                    if(alias != null) {
+                        useImports.put(alias, phpUse.getFQN());
+                    } else {
+                        useImports.put(phpUse.getName(), phpUse.getFQN());
+                    }
                 }
             }
-
-        });
+        }
 
         return useImports;
     }


### PR DESCRIPTION
1. It is extremely expensive to use a recursive visitor on the whole file without restricting/stopping it. In PhpStorm we always try to avoid them at any cost. AFAICS, annotations which are processed on indexing phase can only be placed on functions or members. Those are top-level elements thus there's no need to use a visitor. Each `PhpFile` has prebuilt (which means fast and re-usable) index of such elements. I've replaced a usage of the recursive visitor with simple iteration.
2. I've replaced handmade imports collector with the utility one to get rid of yet another recursive visitor.
3. To avoid exceptions during deserialization, I've implemented equals/hashCode for all elements which are potentially involved in the building of value index.

Overall, with all the changes both indices are built 3 times faster when applying this patch.

Please note that I don't have a domain knowledge so it is possible that some of my assumptions are wrong. Please validate them carefully. Also, I didn't find any test so was not able to properly test the results. But on the first glance everything's work as before.

I'll be glad to answer any questions.