### PR TITLE
Fix matching logic for complex pointcuts combined with ||

### DIFF
--- a/src/main/kotlin/com/aopphp/go/pointcut/AndPointcut.kt
+++ b/src/main/kotlin/com/aopphp/go/pointcut/AndPointcut.kt
@@ -19,6 +19,7 @@ open class AndPointcut(
 
     protected fun isMatchesPointcut(point: PhpNamedElement, pointcut: Pointcut): Boolean {
         if (point !is PhpClassMember) return false
+        if (!pointcut.getKind().supports(point)) return false
         val containingClass = point.containingClass ?: return false
         return pointcut.matches(point) && pointcut.getClassFilter().matches(containingClass)
     }

--- a/src/main/kotlin/com/aopphp/go/pointcut/AttributePointcut.kt
+++ b/src/main/kotlin/com/aopphp/go/pointcut/AttributePointcut.kt
@@ -4,8 +4,6 @@ import com.aopphp.go.index.AttributePhpNamedElementIndex
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.util.indexing.FileBasedIndex
 import com.jetbrains.php.PhpIndex
-import com.jetbrains.php.lang.psi.elements.Field
-import com.jetbrains.php.lang.psi.elements.Method
 import com.jetbrains.php.lang.psi.elements.PhpAttributesOwner
 import com.jetbrains.php.lang.psi.elements.PhpClass
 import com.jetbrains.php.lang.psi.elements.PhpNamedElement
@@ -23,16 +21,9 @@ class AttributePointcut(
     override fun getClassFilter() = _classFilter
 
     override fun matches(element: PhpNamedElement): Boolean {
-        if (!canMatchElement(element)) return false
+        if (!filterKind.supports(element)) return false
         if (element !is PhpAttributesOwner) return false
         return element.getAttributes(expectedClass).isNotEmpty()
-    }
-
-    private fun canMatchElement(element: PhpNamedElement) = when (element) {
-        is Method    -> filterKind.contains(KindFilter.KIND_METHOD)
-        is Field     -> filterKind.contains(KindFilter.KIND_PROPERTY)
-        is PhpClass  -> filterKind.contains(KindFilter.KIND_CLASS)
-        else         -> false
     }
 
     override fun getKind() = filterKind

--- a/src/main/kotlin/com/aopphp/go/pointcut/KindFilter.kt
+++ b/src/main/kotlin/com/aopphp/go/pointcut/KindFilter.kt
@@ -1,5 +1,9 @@
 package com.aopphp.go.pointcut
 
+import com.jetbrains.php.lang.psi.elements.Field
+import com.jetbrains.php.lang.psi.elements.Method
+import com.jetbrains.php.lang.psi.elements.PhpClass
+import com.jetbrains.php.lang.psi.elements.PhpNamedElement
 import java.io.Serializable
 
 enum class KindFilter : Serializable {
@@ -11,4 +15,18 @@ enum class KindFilter : Serializable {
     KIND_INIT,
     KIND_STATIC_INIT,
     KIND_DYNAMIC
+}
+
+/**
+ * Checks whether this set of kinds can match the given element's join point kind.
+ *
+ * This is the matching "context" from goaop/framework#274: without it, each part of a
+ * combined pointcut (e.g. `execution(...) || access(...)`) would be consulted for every
+ * element kind and could match by name pattern alone.
+ */
+fun Set<KindFilter>.supports(element: PhpNamedElement): Boolean = when (element) {
+    is Method   -> KindFilter.KIND_METHOD in this
+    is Field    -> KindFilter.KIND_PROPERTY in this
+    is PhpClass -> KindFilter.KIND_CLASS in this
+    else        -> false
 }

--- a/src/main/kotlin/com/aopphp/go/pointcut/SignaturePointcut.kt
+++ b/src/main/kotlin/com/aopphp/go/pointcut/SignaturePointcut.kt
@@ -28,6 +28,7 @@ class SignaturePointcut(
     override fun getClassFilter() = _classFilter
 
     override fun matches(element: PhpNamedElement): Boolean {
+        if (!filterKind.supports(element)) return false
         if (element is PhpClassMember && !modifierFilter.matches(element)) return false
 
         val elementName = when (element) {

--- a/src/test/kotlin/com/aopphp/go/pointcut/AndPointcutTest.kt
+++ b/src/test/kotlin/com/aopphp/go/pointcut/AndPointcutTest.kt
@@ -1,11 +1,16 @@
 package com.aopphp.go.pointcut
 
+import com.jetbrains.php.lang.psi.elements.Field
+import com.jetbrains.php.lang.psi.elements.Method
 import com.jetbrains.php.lang.psi.elements.PhpClass
 import com.jetbrains.php.lang.psi.elements.PhpClassMember
 import com.jetbrains.php.lang.psi.elements.PhpNamedElement
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
 class AndPointcutTest {
@@ -47,11 +52,24 @@ class AndPointcutTest {
 
     @Test
     fun `matches returns false when containingClass is null`() {
-        val member = mock<PhpClassMember>()
+        val member = mock<Method>()
         whenever(member.containingClass).thenReturn(null)
         val first = mockTruePointcut()
         val second = mockTruePointcut()
         assertFalse(AndPointcut(first, second).matches(member))
+    }
+
+    @Test
+    fun `matches returns false when child pointcut kind does not support element kind`() {
+        val cls = mock<PhpClass>()
+        val field = mock<Field>()
+        whenever(field.containingClass).thenReturn(cls)
+        val first = mockPointcutMatching(field, cls, true, setOf(KindFilter.KIND_METHOD))
+        val second = mockPointcutMatching(field, cls, true, setOf(KindFilter.KIND_METHOD))
+        assertFalse(AndPointcut(first, second).matches(field))
+        // The kind gate must short-circuit before the child pointcut is consulted
+        verify(first, never()).matches(any())
+        verify(second, never()).matches(any())
     }
 
     @Test
@@ -92,19 +110,24 @@ class AndPointcutTest {
     // ---- Helpers ----
 
     private fun mockMemberInClass(cls: PhpClass): PhpClassMember {
-        val member = mock<PhpClassMember>()
+        val member = mock<Method>()
         whenever(member.containingClass).thenReturn(cls)
         return member
     }
 
-    private fun mockPointcutMatching(member: PhpClassMember, cls: PhpClass, matches: Boolean): Pointcut {
+    private fun mockPointcutMatching(
+        member: PhpClassMember,
+        cls: PhpClass,
+        matches: Boolean,
+        kinds: Set<KindFilter> = KindFilter.entries.toSet()
+    ): Pointcut {
         val classFilter = mock<PointFilter>()
         whenever(classFilter.matches(cls)).thenReturn(matches)
-        whenever(classFilter.getKind()).thenReturn(KindFilter.entries.toSet())
+        whenever(classFilter.getKind()).thenReturn(kinds)
         val pointcut = mock<Pointcut>()
         whenever(pointcut.matches(member)).thenReturn(matches)
         whenever(pointcut.getClassFilter()).thenReturn(classFilter)
-        whenever(pointcut.getKind()).thenReturn(KindFilter.entries.toSet())
+        whenever(pointcut.getKind()).thenReturn(kinds)
         return pointcut
     }
 

--- a/src/test/kotlin/com/aopphp/go/pointcut/KindFilterTest.kt
+++ b/src/test/kotlin/com/aopphp/go/pointcut/KindFilterTest.kt
@@ -1,7 +1,12 @@
 package com.aopphp.go.pointcut
 
+import com.jetbrains.php.lang.psi.elements.Field
+import com.jetbrains.php.lang.psi.elements.Method
+import com.jetbrains.php.lang.psi.elements.PhpClass
+import com.jetbrains.php.lang.psi.elements.PhpNamedElement
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
 
 class KindFilterTest {
 
@@ -34,5 +39,49 @@ class KindFilterTest {
     fun `all entries form a full set`() {
         val allKinds = KindFilter.entries.toSet()
         assertEquals(8, allKinds.size)
+    }
+
+    // ---- supports ----
+
+    @Test
+    fun `supports returns true for Method when set contains KIND_METHOD`() {
+        assertTrue(setOf(KindFilter.KIND_METHOD).supports(mock<Method>()))
+    }
+
+    @Test
+    fun `supports returns false for Method when set lacks KIND_METHOD`() {
+        assertFalse(setOf(KindFilter.KIND_PROPERTY, KindFilter.KIND_CLASS).supports(mock<Method>()))
+    }
+
+    @Test
+    fun `supports returns true for Field when set contains KIND_PROPERTY`() {
+        assertTrue(setOf(KindFilter.KIND_PROPERTY).supports(mock<Field>()))
+    }
+
+    @Test
+    fun `supports returns false for Field when set lacks KIND_PROPERTY`() {
+        assertFalse(setOf(KindFilter.KIND_METHOD, KindFilter.KIND_CLASS).supports(mock<Field>()))
+    }
+
+    @Test
+    fun `supports returns true for PhpClass when set contains KIND_CLASS`() {
+        assertTrue(setOf(KindFilter.KIND_CLASS).supports(mock<PhpClass>()))
+    }
+
+    @Test
+    fun `supports returns false for PhpClass when set lacks KIND_CLASS`() {
+        assertFalse(setOf(KindFilter.KIND_METHOD, KindFilter.KIND_PROPERTY).supports(mock<PhpClass>()))
+    }
+
+    @Test
+    fun `supports returns false for plain PhpNamedElement even with all kinds`() {
+        assertFalse(KindFilter.entries.toSet().supports(mock<PhpNamedElement>()))
+    }
+
+    @Test
+    fun `empty kind set supports nothing`() {
+        assertFalse(emptySet<KindFilter>().supports(mock<Method>()))
+        assertFalse(emptySet<KindFilter>().supports(mock<Field>()))
+        assertFalse(emptySet<KindFilter>().supports(mock<PhpClass>()))
     }
 }

--- a/src/test/kotlin/com/aopphp/go/pointcut/OrPointcutKindMatchingTest.kt
+++ b/src/test/kotlin/com/aopphp/go/pointcut/OrPointcutKindMatchingTest.kt
@@ -1,0 +1,106 @@
+package com.aopphp.go.pointcut
+
+import com.jetbrains.php.lang.psi.elements.Field
+import com.jetbrains.php.lang.psi.elements.Method
+import com.jetbrains.php.lang.psi.elements.PhpClass
+import com.jetbrains.php.lang.psi.elements.PhpModifier
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+/**
+ * Regression tests for issue #9: a combination with `||` must not let a sub-pointcut
+ * of one join point kind match elements of another kind.
+ *
+ * Models the pointcut `execution(public **->data*(*)) || access(public **->$id*)`
+ * with real [SignaturePointcut]s: before the fix, a public field named `dataMap`
+ * was matched by the execution clause purely by name pattern (and a method named
+ * `idGenerator` by the access clause).
+ */
+class OrPointcutKindMatchingTest {
+
+    private val executionClause = SignaturePointcut(
+        setOf(KindFilter.KIND_METHOD),
+        "data*",
+        MemberAccessMatcherFilter(setOf(PhpModifier.Access.PUBLIC))
+    )
+
+    private val accessClause = SignaturePointcut(
+        setOf(KindFilter.KIND_PROPERTY),
+        "id*",
+        MemberAccessMatcherFilter(setOf(PhpModifier.Access.PUBLIC))
+    )
+
+    private val orPointcut = OrPointcut(executionClause, accessClause)
+
+    @Test
+    fun `field matching execution name pattern is not matched`() {
+        // The issue #9 false positive: field "dataMap" matches "data*" by name,
+        // but the execution clause is KIND_METHOD and must not apply to fields
+        val field = mockField("dataMap")
+        assertFalse(orPointcut.matches(field))
+    }
+
+    @Test
+    fun `method matching access name pattern is not matched`() {
+        // Symmetric case: method "idGenerator" matches "id*" of the access clause
+        val method = mockMethod("idGenerator")
+        assertFalse(orPointcut.matches(method))
+    }
+
+    @Test
+    fun `method matching execution clause still matches`() {
+        val method = mockMethod("dataLoader")
+        assertTrue(orPointcut.matches(method))
+    }
+
+    @Test
+    fun `field matching access clause still matches`() {
+        val field = mockField("idNumber")
+        assertTrue(orPointcut.matches(field))
+    }
+
+    @Test
+    fun `class-kind true pointcut in or does not leak members`() {
+        // Models `execution(public **->data*(*)) || initialization(**)`: the
+        // initialization clause compiles to TruePointcut(KIND_CLASS) whose matches()
+        // is always true — it must not make every method match through the OR branch
+        val orWithInit = OrPointcut(executionClause, TruePointcut(setOf(KindFilter.KIND_CLASS)))
+        assertFalse(orWithInit.matches(mockMethod("unrelated")))
+        assertFalse(orWithInit.matches(mockField("unrelated")))
+        assertTrue(orWithInit.matches(mockMethod("dataLoader")))
+    }
+
+    @Test
+    fun `and of cross-kind pointcuts matches nothing`() {
+        // No single element can be both a method and a property
+        val andPointcut = AndPointcut(executionClause, accessClause)
+        assertFalse(andPointcut.matches(mockMethod("dataLoader")))
+        assertFalse(andPointcut.matches(mockField("idNumber")))
+    }
+
+    @Test
+    fun `or kind is still the union of both clause kinds`() {
+        // PointcutAdvisor.getMatchedElements relies on the union to collect members
+        assertEquals(setOf(KindFilter.KIND_METHOD, KindFilter.KIND_PROPERTY), orPointcut.getKind())
+    }
+
+    // ---- Helpers ----
+
+    private fun mockMethod(name: String): Method {
+        val method = mock<Method>()
+        whenever(method.name).thenReturn(name)
+        whenever(method.containingClass).thenReturn(mock<PhpClass>())
+        whenever(method.modifier).thenReturn(PhpModifier.PUBLIC_IMPLEMENTED_DYNAMIC)
+        return method
+    }
+
+    private fun mockField(name: String): Field {
+        val field = mock<Field>()
+        whenever(field.name).thenReturn(name)
+        whenever(field.containingClass).thenReturn(mock<PhpClass>())
+        whenever(field.modifier).thenReturn(PhpModifier.PUBLIC_IMPLEMENTED_DYNAMIC)
+        return field
+    }
+}

--- a/src/test/kotlin/com/aopphp/go/pointcut/OrPointcutTest.kt
+++ b/src/test/kotlin/com/aopphp/go/pointcut/OrPointcutTest.kt
@@ -1,11 +1,16 @@
 package com.aopphp.go.pointcut
 
+import com.jetbrains.php.lang.psi.elements.Field
+import com.jetbrains.php.lang.psi.elements.Method
 import com.jetbrains.php.lang.psi.elements.PhpClass
 import com.jetbrains.php.lang.psi.elements.PhpClassMember
 import com.jetbrains.php.lang.psi.elements.PhpNamedElement
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
 class OrPointcutTest {
@@ -56,11 +61,36 @@ class OrPointcutTest {
 
     @Test
     fun `matches returns false when containingClass is null`() {
-        val member = mock<PhpClassMember>()
+        val member = mock<Method>()
         whenever(member.containingClass).thenReturn(null)
         val first = mockTruePointcut()
         val second = mockTruePointcut()
         assertFalse(OrPointcut(first, second).matches(member))
+    }
+
+    @Test
+    fun `matches returns false when no child pointcut kind supports element kind`() {
+        val cls = mock<PhpClass>()
+        val field = mock<Field>()
+        whenever(field.containingClass).thenReturn(cls)
+        val first = mockPointcutMatching(field, cls, true, setOf(KindFilter.KIND_METHOD))
+        val second = mockPointcutMatching(field, cls, true, setOf(KindFilter.KIND_METHOD))
+        assertFalse(OrPointcut(first, second).matches(field))
+        // The kind gate must short-circuit before either child pointcut is consulted
+        verify(first, never()).matches(any())
+        verify(second, never()).matches(any())
+    }
+
+    @Test
+    fun `matches consults only the child whose kind supports the element`() {
+        val cls = mock<PhpClass>()
+        val field = mock<Field>()
+        whenever(field.containingClass).thenReturn(cls)
+        val methodOnly = mockPointcutMatching(field, cls, true, setOf(KindFilter.KIND_METHOD))
+        val propertyOnly = mockPointcutMatching(field, cls, true, setOf(KindFilter.KIND_PROPERTY))
+        assertTrue(OrPointcut(methodOnly, propertyOnly).matches(field))
+        verify(methodOnly, never()).matches(any())
+        verify(propertyOnly).matches(field)
     }
 
     @Test
@@ -93,19 +123,24 @@ class OrPointcutTest {
     // ---- Helpers ----
 
     private fun mockMemberInClass(cls: PhpClass): PhpClassMember {
-        val member = mock<PhpClassMember>()
+        val member = mock<Method>()
         whenever(member.containingClass).thenReturn(cls)
         return member
     }
 
-    private fun mockPointcutMatching(member: PhpClassMember, cls: PhpClass, matches: Boolean): Pointcut {
+    private fun mockPointcutMatching(
+        member: PhpClassMember,
+        cls: PhpClass,
+        matches: Boolean,
+        kinds: Set<KindFilter> = KindFilter.entries.toSet()
+    ): Pointcut {
         val classFilter = mock<PointFilter>()
         whenever(classFilter.matches(cls)).thenReturn(matches)
-        whenever(classFilter.getKind()).thenReturn(KindFilter.entries.toSet())
+        whenever(classFilter.getKind()).thenReturn(kinds)
         val pointcut = mock<Pointcut>()
         whenever(pointcut.matches(member)).thenReturn(matches)
         whenever(pointcut.getClassFilter()).thenReturn(classFilter)
-        whenever(pointcut.getKind()).thenReturn(KindFilter.entries.toSet())
+        whenever(pointcut.getKind()).thenReturn(kinds)
         return pointcut
     }
 

--- a/src/test/kotlin/com/aopphp/go/pointcut/SignaturePointcutTest.kt
+++ b/src/test/kotlin/com/aopphp/go/pointcut/SignaturePointcutTest.kt
@@ -1,5 +1,7 @@
 package com.aopphp.go.pointcut
 
+import com.jetbrains.php.lang.psi.elements.Field
+import com.jetbrains.php.lang.psi.elements.Method
 import com.jetbrains.php.lang.psi.elements.PhpClass
 import com.jetbrains.php.lang.psi.elements.PhpClassMember
 import com.jetbrains.php.lang.psi.elements.PhpModifier
@@ -16,14 +18,14 @@ class SignaturePointcutTest {
     // ---- Exact name matching ----
 
     @Test
-    fun `matches PhpClassMember by exact name`() {
+    fun `matches Method by exact name`() {
         val pointcut = SignaturePointcut(setOf(KindFilter.KIND_METHOD), "doSomething", TruePointFilter)
         val method = mockMember("doSomething")
         assertTrue(pointcut.matches(method))
     }
 
     @Test
-    fun `does not match PhpClassMember with different name`() {
+    fun `does not match Method with different name`() {
         val pointcut = SignaturePointcut(setOf(KindFilter.KIND_METHOD), "doSomething", TruePointFilter)
         val method = mockMember("otherMethod")
         assertFalse(pointcut.matches(method))
@@ -44,19 +46,51 @@ class SignaturePointcutTest {
     }
 
     @Test
-    fun `returns empty string for non-member non-class element and does not match non-empty name`() {
+    fun `does not match non-member non-class element`() {
         val pointcut = SignaturePointcut(setOf(KindFilter.KIND_METHOD), "something", TruePointFilter)
         val element = mock<PhpNamedElement>()
-        // element is neither PhpClassMember nor PhpClass -> elementName = ""
+        // element is neither Method, Field nor PhpClass -> rejected by the kind gate
         assertFalse(pointcut.matches(element))
     }
 
     @Test
-    fun `matches element when name is empty string and pattern is also empty`() {
+    fun `does not match unsupported element kind even when name pattern is empty`() {
         val pointcut = SignaturePointcut(setOf(KindFilter.KIND_METHOD), "", TruePointFilter)
         val element = mock<PhpNamedElement>()
-        // elementName = "" and name = "" → exact match
-        assertTrue(pointcut.matches(element))
+        // the kind gate rejects the element before any name matching happens
+        assertFalse(pointcut.matches(element))
+    }
+
+    // ---- Kind gate ----
+
+    @Test
+    fun `does not match Field when kind is KIND_METHOD`() {
+        val pointcut = SignaturePointcut(setOf(KindFilter.KIND_METHOD), "get*", TruePointFilter)
+        val field = mock<Field>()
+        whenever(field.name).thenReturn("getUser")
+        assertFalse(pointcut.matches(field))
+    }
+
+    @Test
+    fun `does not match Method when kind is KIND_PROPERTY`() {
+        val pointcut = SignaturePointcut(setOf(KindFilter.KIND_PROPERTY), "get*", TruePointFilter)
+        val method = mock<Method>()
+        whenever(method.name).thenReturn("getUser")
+        assertFalse(pointcut.matches(method))
+    }
+
+    @Test
+    fun `matches Field by name when kind is KIND_PROPERTY`() {
+        val pointcut = SignaturePointcut(setOf(KindFilter.KIND_PROPERTY), "get*", TruePointFilter)
+        val field = mock<Field>()
+        whenever(field.name).thenReturn("getUser")
+        assertTrue(pointcut.matches(field))
+    }
+
+    @Test
+    fun `does not match PhpClass when kind excludes KIND_CLASS`() {
+        val pointcut = SignaturePointcut(setOf(KindFilter.KIND_METHOD), "App\\MyClass", TruePointFilter)
+        assertFalse(pointcut.matches(mockClass("\\App\\MyClass")))
     }
 
     // ---- Wildcard matching ----
@@ -115,7 +149,7 @@ class SignaturePointcutTest {
     fun `returns false when modifier filter rejects the member`() {
         val modFilter = MemberAccessMatcherFilter(setOf(PhpModifier.Access.PUBLIC))
         val pointcut = SignaturePointcut(setOf(KindFilter.KIND_METHOD), "doSomething", modFilter)
-        val method = mock<PhpClassMember>()
+        val method = mock<Method>()
         whenever(method.name).thenReturn("doSomething")
         whenever(method.modifier).thenReturn(PhpModifier.PRIVATE_IMPLEMENTED_DYNAMIC)
         assertFalse(pointcut.matches(method))
@@ -125,7 +159,7 @@ class SignaturePointcutTest {
     fun `returns true when modifier filter accepts the member`() {
         val modFilter = MemberAccessMatcherFilter(setOf(PhpModifier.Access.PUBLIC))
         val pointcut = SignaturePointcut(setOf(KindFilter.KIND_METHOD), "doSomething", modFilter)
-        val method = mock<PhpClassMember>()
+        val method = mock<Method>()
         whenever(method.name).thenReturn("doSomething")
         whenever(method.modifier).thenReturn(PhpModifier.PUBLIC_IMPLEMENTED_DYNAMIC)
         assertTrue(pointcut.matches(method))
@@ -190,7 +224,7 @@ class SignaturePointcutTest {
     // ---- Helpers ----
 
     private fun mockMember(name: String): PhpClassMember {
-        val m = mock<PhpClassMember>()
+        val m = mock<Method>()
         whenever(m.name).thenReturn(name)
         return m
     }


### PR DESCRIPTION
Fixes #9

## Problem

Combined pointcuts delegated matching to each sub-pointcut regardless of the element's join point kind. In an expression like

```
execution(public **->data*(*)) || access(public **->$id*)
```

the `KIND_METHOD` execution clause could match a **field** named `dataMap` purely by name pattern (and the access clause could match methods named `id*`), producing false-positive line markers. `OrPointcut.getKind()` is the union of the clause kinds and `PointcutAdvisor` gates only on that aggregate, so the wrong-kind element always reached the kind-blind clause. A related leak: `... || initialization(Foo)` compiles the initialization branch to `TruePointcut(KIND_CLASS)` whose `matches()` is always `true`, so every member of a matching class matched through that OR branch.

## Fix

Adds the matching *context* from goaop/framework#274 (the join-point kind) as a gate on sub-pointcut delegation:

- New `Set<KindFilter>.supports(element)` extension in `KindFilter.kt` maps `Method`/`Field`/`PhpClass` elements to `KIND_METHOD`/`KIND_PROPERTY`/`KIND_CLASS`.
- `AndPointcut.isMatchesPointcut` (shared by `OrPointcut` via inheritance) now skips sub-pointcuts whose kind set does not support the element — this also fixes the `initialization()` leak above.
- `SignaturePointcut.matches()` now checks its own `filterKind`, consistent with how `AttributePointcut` already behaved.
- `AttributePointcut` reuses the shared helper instead of its private `canMatchElement` (behavior unchanged).

Not touched: modifier matching (`MemberAccessMatcherFilter` + `MemberStateMatcherFilter`) already evaluates `public|protected` + `static` correctly as `(public || protected) && static`, so the goaop/framework#293 variant of this bug does not exist in the plugin.

## Tests

- New `OrPointcutKindMatchingTest` regression suite using real `SignaturePointcut`s that mirrors the issue scenario: cross-kind false positives are rejected while legitimate matches of each clause still work, `TruePointcut(KIND_CLASS)` no longer leaks members through an OR, and the OR kind stays the union (which `PointcutAdvisor.getMatchedElements` relies on).
- Kind-gate unit tests in `AndPointcutTest`/`OrPointcutTest` verifying the gate short-circuits before the sub-pointcut is consulted, and that only the kind-compatible child is delegated to.
- `supports()` coverage in `KindFilterTest`; kind-mismatch cases in `SignaturePointcutTest`.
- Existing mocks tightened from bare `PhpClassMember` to `Method` so they represent real PSI elements and pass the stricter gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015GwCyE8P8udW5VMJHY4qGk

---
_Generated by [Claude Code](https://claude.ai/code/session_015GwCyE8P8udW5VMJHY4qGk)_